### PR TITLE
pmx: add arc time registers

### DIFF
--- a/pmx/pmx.ino
+++ b/pmx/pmx.ino
@@ -26,6 +26,8 @@ const int   rMode        = 8339;  // cut mode register #
 const int   rPressure    = 8342;  // pressure register #
 const int   rPressureMax = 8349;  // pressure max register #
 const int   rPressureMin = 8348;  // pressure min register #
+const int   rArcTimeLow  = 8350;  // arc time low register #
+const int   rArcTimeHigh = 8351;  // arc time high register #
 
 // TEMP GLOBAL FOR TEST
 byte bob;

--- a/pmx/register_read.ino
+++ b/pmx/register_read.ino
@@ -22,6 +22,10 @@ bool register_read(){ // READ REGISTER
     tmpI = cPressureMin * 128;
   }else if((int)strtol(inRegister, NULL, 16) == rPressureMax){
     tmpI = cPressureMax * 128;
+  }else if((int)strtol(inRegister, NULL, 16) == rArcTimeLow){
+    tmpI = 65535;
+  }else if((int)strtol(inRegister, NULL, 16) == rArcTimeHigh){
+    tmpI = 0;
   }
 
   utoa(tmpI, tmpD, 16);


### PR DESCRIPTION
Added arc time registers, and hard-coded rArcTimeHigh to 0 and rArcTimeLow to 65535 (hex FFFF), which will give a total arc time of 18h 12m 15s.